### PR TITLE
Added change by grese

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -437,6 +437,14 @@ type ConnectionOptionsOTP struct {
 	Length   *int `json:"length,omitempty"`
 }
 
+type ConnectionGatewayAuthentication struct {
+	Method              *string `json:"method,omitempty"`
+	Subject             *string `json:"subject,omitempty"`
+	Audience            *string `json:"audience,omitempty"`
+	Secret              *string `json:"secret,omitempty"`
+	SecretBase64Encoded *bool   `json:"secret_base64_encoded,omitempty"`
+}
+
 type ConnectionOptionsSMS struct {
 	Name     *string `json:"name,omitempty"`
 	From     *string `json:"from,omitempty"`
@@ -447,9 +455,14 @@ type ConnectionOptionsSMS struct {
 
 	AuthParams map[string]string `json:"authParams,omitempty"`
 
-	TwilioSID           *string `json:"twilio_sid"`
-	TwilioToken         *string `json:"twilio_token"`
-	MessagingServiceSID *string `json:"messaging_service_sid"`
+	TwilioSID           *string `json:"twilio_sid,omitempty"`
+	TwilioToken         *string `json:"twilio_token,omitempty"`
+	MessagingServiceSID *string `json:"messaging_service_sid,omitempty"`
+
+	Provider              *string                          `json:"provider,omitempty"`
+	GatewayUrl            *string                          `json:"gateway_url,omitempty"`
+	GatewayAuthentication *ConnectionGatewayAuthentication `json:"gateway_authentication,omitempty"`
+	ForwardRequestInfo    *bool                            `json:"forward_request_info,omitempty"`
 
 	DisableSignup        *bool `json:"disable_signup,omitempty"`
 	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -450,6 +450,70 @@ func TestConnectionOptions(t *testing.T) {
 		t.Logf("%s\n", s)
 	})
 
+	t.Run("CustomSMS", func(t *testing.T) {
+
+		s := &Connection{
+			Name:     auth0.Stringf("Test-Connection-Custom-SMS-%d", time.Now().Unix()),
+			Strategy: auth0.String("sms"),
+			Options: &ConnectionOptionsSMS{
+				From:     auth0.String("+17777777777"),
+				Template: auth0.String("Your verification code is { code }}"),
+				Syntax:   auth0.String("liquid"),
+				OTP: &ConnectionOptionsOTP{
+					TimeStep: auth0.Int(110),
+					Length:   auth0.Int(5),
+				},
+				BruteForceProtection: auth0.Bool(true),
+				DisableSignup:        auth0.Bool(false),
+				Name:                 auth0.String("Test-Connection-Custom-SMS"),
+				Provider:             auth0.String("sms_gateway"),
+				GatewayUrl:           auth0.String("https://test.com/sms-gateway"),
+				GatewayAuthentication: &ConnectionGatewayAuthentication{
+					Method:              auth0.String("bearer"),
+					Subject:             auth0.String("test.us.auth0.com:sms"),
+					Audience:            auth0.String("test.com/sms-gateway"),
+					Secret:              auth0.String("my-secret"),
+					SecretBase64Encoded: auth0.Bool(false),
+				},
+				ForwardRequestInfo: auth0.Bool(true),
+			},
+		}
+
+		defer func() {
+			m.Connection.Delete(s.GetID())
+			assertDeleted(t, s)
+		}()
+
+		err := m.Connection.Create(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		o, ok := s.Options.(*ConnectionOptionsSMS)
+		if !ok {
+			t.Fatalf("unexpected type %T", o)
+		}
+
+		expect.Expect(t, o.GetTemplate(), "Your verification code is { code }}")
+		expect.Expect(t, o.GetFrom(), "+17777777777")
+		expect.Expect(t, o.GetSyntax(), "liquid")
+		expect.Expect(t, o.GetOTP().GetTimeStep(), 110)
+		expect.Expect(t, o.GetOTP().GetLength(), 5)
+		expect.Expect(t, o.GetBruteForceProtection(), true)
+		expect.Expect(t, o.GetDisableSignup(), true)
+		expect.Expect(t, o.GetName(), "Test-Connection-Custom-SMS")
+		expect.Expect(t, o.GetProvider(), "sms_gateway")
+		expect.Expect(t, o.GetGatewayUrl(), "https://test.com/sms-gateway")
+		expect.Expect(t, o.GetGatewayAuthentication().GetMethod(), "bearer")
+		expect.Expect(t, o.GetGatewayAuthentication().GetSubject(), "test.us.auth0.com:sms")
+		expect.Expect(t, o.GetGatewayAuthentication().GetAudience(), "test.com/sms-gateway")
+		expect.Expect(t, o.GetGatewayAuthentication().GetSecret(), "my-secret")
+		expect.Expect(t, o.GetGatewayAuthentication().GetSecretBase64Encoded(), false)
+		expect.Expect(t, o.GetForwardRequestInfo(), true)
+
+		t.Logf("%s\n", s)
+	})
+
 	t.Run("SAML", func(t *testing.T) {
 
 		g := &Connection{

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -975,6 +975,51 @@ func (c *Connection) String() string {
 	return Stringify(c)
 }
 
+// GetAudience returns the Audience field if it's non-nil, zero value otherwise.
+func (c *ConnectionGatewayAuthentication) GetAudience() string {
+	if c == nil || c.Audience == nil {
+		return ""
+	}
+	return *c.Audience
+}
+
+// GetMethod returns the Method field if it's non-nil, zero value otherwise.
+func (c *ConnectionGatewayAuthentication) GetMethod() string {
+	if c == nil || c.Method == nil {
+		return ""
+	}
+	return *c.Method
+}
+
+// GetSecret returns the Secret field if it's non-nil, zero value otherwise.
+func (c *ConnectionGatewayAuthentication) GetSecret() string {
+	if c == nil || c.Secret == nil {
+		return ""
+	}
+	return *c.Secret
+}
+
+// GetSecretBase64Encoded returns the SecretBase64Encoded field if it's non-nil, zero value otherwise.
+func (c *ConnectionGatewayAuthentication) GetSecretBase64Encoded() bool {
+	if c == nil || c.SecretBase64Encoded == nil {
+		return false
+	}
+	return *c.SecretBase64Encoded
+}
+
+// GetSubject returns the Subject field if it's non-nil, zero value otherwise.
+func (c *ConnectionGatewayAuthentication) GetSubject() string {
+	if c == nil || c.Subject == nil {
+		return ""
+	}
+	return *c.Subject
+}
+
+// String returns a string representation of ConnectionGatewayAuthentication.
+func (c *ConnectionGatewayAuthentication) String() string {
+	return Stringify(c)
+}
+
 // String returns a string representation of ConnectionList.
 func (c *ConnectionList) String() string {
 	return Stringify(c)
@@ -3070,12 +3115,36 @@ func (c *ConnectionOptionsSMS) GetDisableSignup() bool {
 	return *c.DisableSignup
 }
 
+// GetForwardRequestInfo returns the ForwardRequestInfo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetForwardRequestInfo() bool {
+	if c == nil || c.ForwardRequestInfo == nil {
+		return false
+	}
+	return *c.ForwardRequestInfo
+}
+
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSMS) GetFrom() string {
 	if c == nil || c.From == nil {
 		return ""
 	}
 	return *c.From
+}
+
+// GetGatewayAuthentication returns the GatewayAuthentication field.
+func (c *ConnectionOptionsSMS) GetGatewayAuthentication() *ConnectionGatewayAuthentication {
+	if c == nil {
+		return nil
+	}
+	return c.GatewayAuthentication
+}
+
+// GetGatewayUrl returns the GatewayUrl field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetGatewayUrl() string {
+	if c == nil || c.GatewayUrl == nil {
+		return ""
+	}
+	return *c.GatewayUrl
 }
 
 // GetMessagingServiceSID returns the MessagingServiceSID field if it's non-nil, zero value otherwise.
@@ -3100,6 +3169,14 @@ func (c *ConnectionOptionsSMS) GetOTP() *ConnectionOptionsOTP {
 		return nil
 	}
 	return c.OTP
+}
+
+// GetProvider returns the Provider field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetProvider() string {
+	if c == nil || c.Provider == nil {
+		return ""
+	}
+	return *c.Provider
 }
 
 // GetSyntax returns the Syntax field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
Ref PR : https://github.com/go-auth0/auth0/pull/230

Proposed Changes
Adding support for custom sms gateway as described in alexkappa/terraform-provider-auth0 #416, and implemented in alexkappa/terraform-provider-auth0 #417. This PR makes the following changes:

Add "omitempty" to TwilioSID, TwilioToken, and MessagingServiceSID (they need to be omitted for custom gateway)
Add Provider, GatewayUrl, GatewayAuthentication, and ForwardRequestInfo fields to ConnectionOptionsSMS
Added ConnectionGatewayAuthentication to support the custom authentication options for tokens sent to sms gateway